### PR TITLE
Return matches with the same calculated distance

### DIFF
--- a/lib/knnball/kdtree.rb
+++ b/lib/knnball/kdtree.rb
@@ -94,7 +94,7 @@ module KnnBall
           # retrieve the splitting node.
           split_node = (coord[dim] <= current_node.center[dim] ? current_node.right : current_node.left)
           best_dist = results.barrier_value
-          if( (coord[dim] - current_node.center[dim]).abs < best_dist)
+          if( (coord[dim] - current_node.center[dim]).abs <= best_dist)
             # potential match, need to investigate subtree
             nearest(coord, root: split_node, results: results)
           end

--- a/test/spec/kdtree_spec.rb
+++ b/test/spec/kdtree_spec.rb
@@ -50,6 +50,21 @@ module KnnBall
       end
     end
 
+    describe "find matches with identical distances" do
+      before :each do
+        root = Ball.new(
+          {:id => 1, :point => [1]}, 1,
+            Ball.new({:id => 2, :point => [1]}, 1),
+            Ball.new({:id => 3, :point => [2]}, 1)
+        )
+        @ball_tree = KDTree.new(root)
+      end
+
+      it "returns all matches" do
+        @ball_tree.nearest([1], :limit => 3).length.must_equal(3)
+      end
+    end
+
     describe "find the parent for coordinates" do
       before :each do
         @root = Ball.new({:id => 4, :point => [5, 7]}, 1,


### PR DESCRIPTION
Any nodes with identical calculated distances are excluded from the result set.  Thanks to @matsadler for pointing out the problem.
